### PR TITLE
test: de-flake delayed-action timing assertion

### DIFF
--- a/tests/integration/generic-action-types.test.ts
+++ b/tests/integration/generic-action-types.test.ts
@@ -372,7 +372,11 @@ describe('Generic Action Types Integration Tests', () => {
       const elapsed = Date.now() - startTime;
 
       expect(result).toBe('delayed-result');
-      expect(elapsed).toBeGreaterThanOrEqual(50);
+      // setTimeout/Date.now can report a hair under the requested delay (timer
+      // and clock resolution differ across platforms), so allow a small underrun.
+      // The resolved value above already proves the Promise was awaited; this
+      // assertion only confirms a real asynchronous delay occurred.
+      expect(elapsed).toBeGreaterThanOrEqual(45);
     });
 
     it('should handle multiple actions with different generic types (Requirement 6.3)', async () => {


### PR DESCRIPTION
@
## What

The integration test `should handle action that returns Promise directly (Requirement 6.3)` asserted `elapsed >= 50` for an action backed by `setTimeout(resolve, 50)`. Timer and clock resolution differ across platforms, so `setTimeout(50)` can resolve with `Date.now()` measuring **49ms** — an intermittent failure.

This actually blocked PR #8: its required `test (node 24)` check failed on exactly this assertion (`expected 49 to be greater than or equal to 50`), unrelated to that branch. A re-run cleared it, but the flake remains for the next PR to hit.

## Fix

Allow a small underrun tolerance (`>= 45`). The existing `expect(result).toBe(...)` assertion already proves the Promise was awaited; the elapsed check only confirms a real asynchronous delay occurred, which 45ms still establishes. A comment documents why the tolerance exists.

## Test

`npx vitest run tests/integration/generic-action-types.test.ts` → 15/15 pass.
@